### PR TITLE
Add multi-language support with EN baseline navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@
 - if a question contains a div with class starting with SliderTrack - this is a VAS slider. To complete a value and move forward, click on the slider track in the middle, top or bottom to record a value
 -change field processing logic, after the data entry on each field, wait 1 second, then evaluate the form from that question to the end. New conditional questions may appear. For each conditional question that appears, record in the JSON the parent question and the value that was selected. As those questions appear, during the data entry, fill them before the other questions after them.    
 
+*** Multi-language Support ***
+- For languages other than EN - there is an assumption that the form options and buttons and all other behaviours are identical to EN form (including selectors) - only the labels and messages on the display are different between languages for the same tuple - ignore the language and version components - use the customer id, study name, package name only.
+- There must always be an EN analysis for the same forms, before other languages can be analysed. Check firestore at the beginning of analysis - or allow an EN analysis.json to be passed as an option instead - verify that the JSON is for an EN form.
+- Use the EN analysis to navigate the non-EN versions and take the same screenshots.
+
 *** Form reset ***
 - On first opening a URL assess if this is the first form.
 - The first form will only display the ‘next’ button.
@@ -69,9 +74,7 @@
 *** Frontend ***
 Use mui-x community edition component library (https://github.com/mui/mui-x) and mui https://github.com/mui/material-ui
 Use firestore and firebase auth and cloud storage 
-Use tailwind
-Use npm
-Use latest React
+UI technical choices can be found in specs/ui-tech.md
 
 *** Screenshots ***
 - The analyse tool should allow a specification of the viewport - default should be 767px x 1024px

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An automated survey form analysis tool that captures form fields, screenshots, a
 - **Test Case Management**: Update status, track reviews, and generate statistics
 - **Automated Test Execution**: Execute test cases on live forms with validation detection
 - **Validation Testing**: Capture form validation states and error messages
+- **Multi-language Support**: Analyze non-EN surveys using EN baseline navigation
 - **Containerized**: Runs completely within Docker with no local dependencies
 
 ## Prerequisites
@@ -77,6 +78,36 @@ docker run --rm -v ./output:/app/output form-shot-runtime analyze <URL> <TUPLE>
 Example:
 ```bash
 docker run --rm -v ./output:/app/output form-shot-runtime analyze https://main.qa.castoredc.org/survey/X9PAYLDQ PXL_KISQ,qa-test,sf36-gad7,en,v1
+```
+
+Options:
+- `--nav-delay <seconds>`: Pause in seconds before clicking navigation buttons (default: 3)
+- `--en-baseline <path>`: Path to EN analysis.json file to use as baseline for non-EN analysis
+
+#### Multi-language Support
+
+Form-Shot supports analyzing surveys in multiple languages using an EN baseline approach:
+
+1. **EN-first requirement**: Before analyzing non-EN versions, you must have an EN analysis
+2. **Baseline navigation**: Non-EN analyses use the EN form structure to navigate
+3. **Language-specific screenshots**: Captures screenshots with localized text
+
+##### Automatic EN baseline lookup (via Firestore):
+```bash
+# First, analyze the EN version
+docker run --rm -v ./output:/app/output -v ~/firestore.json:/app/firestore.json form-shot-runtime analyze https://survey.example.com/X9PAYLDQ PXL_KISQ,qa-test,sf36-gad7,en,v1
+
+# Upload EN analysis to Firestore
+docker run --rm -v ./output:/app/output -v ~/firestore.json:/app/firestore.json form-shot-runtime upload /app/output/PXL_KISQ/qa-test/sf36-gad7/en/v1/analysis.json
+
+# Now analyze DE version (will automatically find EN baseline in Firestore)
+docker run --rm -v ./output:/app/output -v ~/firestore.json:/app/firestore.json form-shot-runtime analyze https://survey.example.com/X9PAYLDQ PXL_KISQ,qa-test,sf36-gad7,de,v1
+```
+
+##### Manual EN baseline (without Firestore):
+```bash
+# Analyze DE version using local EN analysis file
+docker run --rm -v ./output:/app/output form-shot-runtime analyze https://survey.example.com/X9PAYLDQ PXL_KISQ,qa-test,sf36-gad7,de,v1 --en-baseline /app/output/PXL_KISQ/qa-test/sf36-gad7/en/v1/analysis.json
 ```
 
 ### 2. Upload Analysis to Firestore (includes test data)

--- a/packages/cli/src/commands/fix-screenshots.ts
+++ b/packages/cli/src/commands/fix-screenshots.ts
@@ -1,0 +1,61 @@
+import { FirestoreService } from '@form-shot/shared';
+import { logger } from '@form-shot/shared';
+
+export async function fixScreenshots(): Promise<void> {
+  const firestoreService = new FirestoreService();
+  
+  try {
+    // Direct Firestore access
+    const db = (firestoreService as any).db;
+    
+    // Get all analyses
+    const analysesSnapshot = await db.collection('survey-analyses').get();
+    
+    logger.info(`Found ${analysesSnapshot.size} analyses to process`);
+    
+    let updated = 0;
+    let skipped = 0;
+    
+    for (const analysisDoc of analysesSnapshot.docs) {
+      const analysisId = analysisDoc.id;
+      const analysisData = analysisDoc.data();
+      
+      // Skip if already has the screenshot URL
+      if (analysisData.firstFormOnEntryScreenshotUrl) {
+        skipped++;
+        continue;
+      }
+      
+      try {
+        // Get the first form
+        const formsSnapshot = await analysisDoc.ref.collection('forms').orderBy('order').limit(1).get();
+        
+        if (formsSnapshot.empty) {
+          logger.warn(`No forms found for analysis: ${analysisId}`);
+          continue;
+        }
+        
+        const firstForm = formsSnapshot.docs[0].data();
+        
+        // Update the analysis document with the first form's on-entry screenshot URL
+        if (firstForm.onEntryScreenshotUrl) {
+          await analysisDoc.ref.update({
+            firstFormOnEntryScreenshotUrl: firstForm.onEntryScreenshotUrl
+          });
+          updated++;
+          logger.info(`Updated analysis ${analysisId} with screenshot URL`);
+        } else {
+          logger.info(`No on-entry screenshot URL found for analysis: ${analysisId}`);
+        }
+        
+      } catch (error) {
+        logger.error(`Failed to process analysis ${analysisId}:`, error);
+      }
+    }
+    
+    logger.info(`Completed: ${updated} updated, ${skipped} skipped`);
+  } catch (error) {
+    logger.error('Failed to fix screenshots:', error);
+    throw error;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ program
   .argument('<url>', 'URL of the survey form to analyze')
   .argument('<tuple>', 'Tuple string in format: [customer_id,study_id,package_name,language,version]')
   .option('--nav-delay <seconds>', 'Pause in seconds before clicking navigation buttons (default: 3)', '3')
+  .option('--en-baseline <path>', 'Path to EN analysis.json file to use as baseline for non-EN analysis')
   .action(async (url: string, tupleString: string, options) => {
     try {
       // Parse the tuple string
@@ -37,8 +38,11 @@ program
       logger.info(`Starting analysis of ${url}`);
       logger.info(`Tuple: ${JSON.stringify(tuple)}`);
       logger.info(`Navigation delay: ${options.navDelay} seconds`);
+      if (options.enBaseline) {
+        logger.info(`Using EN baseline from: ${options.enBaseline}`);
+      }
       
-      await analyzeSurvey(url, tuple, navDelay);
+      await analyzeSurvey(url, tuple, navDelay, options.enBaseline);
     } catch (error) {
       logger.error('Analysis failed:', error);
       process.exit(1);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from './commands/test-data.js';
 import { runTests } from './commands/test-run.js';
 import { fixAnalysis } from './commands/fix-analysis.js';
+import { fixScreenshots } from './commands/fix-screenshots.js';
 import { SurveyTuple, logger } from '@form-shot/shared';
 
 const program = new Command();
@@ -195,6 +196,18 @@ program
       await fixAnalysis();
     } catch (error) {
       logger.error('Fix analysis failed:', error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('fix-screenshots')
+  .description('Fix existing analyses to add first form screenshot URLs')
+  .action(async () => {
+    try {
+      await fixScreenshots();
+    } catch (error) {
+      logger.error('Fix screenshots failed:', error);
       process.exit(1);
     }
   });

--- a/packages/shared/src/form-analyzer/baseline-navigator.ts
+++ b/packages/shared/src/form-analyzer/baseline-navigator.ts
@@ -1,0 +1,226 @@
+import { Page } from 'puppeteer';
+import { SurveyForm, SurveyField, NavigationButton } from '../types/types.js';
+import { logger } from '../utils/logger.js';
+import { FormNavigator } from './form-navigator.js';
+
+export class BaselineNavigator {
+  private formNavigator: FormNavigator;
+
+  constructor() {
+    this.formNavigator = new FormNavigator();
+  }
+
+  /**
+   * Fill fields and navigate to next form using EN baseline data
+   */
+  async navigateWithBaseline(
+    page: Page,
+    baselineForms: SurveyForm[],
+    navDelay: number = 3000
+  ): Promise<{ formIndex: number; isComplete: boolean }> {
+    // This method now only handles filling fields and navigation for a single form
+    const baselineForm = baselineForms[0];
+    logger.info(`Filling fields and navigating using baseline: ${baselineForm.shortName}`);
+
+    // Fill fields based on baseline data
+    if (baselineForm.fields && baselineForm.fields.length > 0) {
+      logger.info(`Filling ${baselineForm.fields.length} fields from baseline`);
+      await this.fillFieldsFromBaseline(page, baselineForm.fields);
+    }
+
+    // Navigate to next form
+    try {
+      logger.info('Clicking next button to proceed to next form...');
+      await this.formNavigator.clickNavigationButton(page, 'next', navDelay);
+      
+      // Check for validation modal
+      const hasModal = await this.formNavigator.detectValidationModal(page);
+      if (hasModal) {
+        logger.warn('Validation modal detected, closing and retrying...');
+        await this.formNavigator.closeValidationModal(page);
+        // Try to fill any missing fields and click next again
+        await this.formNavigator.fillMissingRequiredFields(page);
+        await this.formNavigator.clickNavigationButton(page, 'next', navDelay);
+      }
+      
+      // Wait for form transition
+      const transitioned = await this.formNavigator.waitForFormTransition(page, baselineForm.longTitle);
+      if (!transitioned) {
+        logger.error('Form transition failed');
+        return { formIndex: 0, isComplete: false };
+      }
+      
+      return { formIndex: 0, isComplete: true };
+    } catch (error) {
+      logger.error('Error navigating to next form:', error);
+      return { formIndex: 0, isComplete: false };
+    }
+  }
+
+  /**
+   * Fill fields based on baseline field data
+   */
+  private async fillFieldsFromBaseline(page: Page, baselineFields: SurveyField[]): Promise<void> {
+    for (const field of baselineFields) {
+      if (!field.isRequired) continue;
+
+      try {
+        // Check if field exists on current page
+        const fieldExists = await page.evaluate((selector) => {
+          return document.querySelector(selector) !== null;
+        }, field.selector);
+
+        if (!fieldExists) {
+          logger.warn(`Field not found with selector: ${field.selector}`);
+          continue;
+        }
+
+        // Fill field based on type
+        switch (field.inputType) {
+          case 'radio':
+            // Select first option for radio buttons
+            if (field.choices && field.choices.length > 0) {
+              await this.selectRadioOption(page, field.cardBoxSelector, 0);
+            }
+            break;
+
+          case 'dropdown':
+            // Select first option for dropdowns
+            if (field.choices && field.choices.length > 0) {
+              await this.selectDropdownOption(page, field.selector, 0);
+            }
+            break;
+
+          case 'text':
+          case 'email':
+          case 'number':
+            // Fill with appropriate test value
+            await this.fillTextField(page, field.selector, field.inputType);
+            break;
+
+          case 'textarea':
+            await page.type(field.selector, 'Test response for multi-language analysis');
+            break;
+
+          case 'checkbox':
+            // Check the checkbox if unchecked
+            await page.evaluate((selector) => {
+              const checkbox = document.querySelector(selector) as HTMLInputElement;
+              if (checkbox && !checkbox.checked) {
+                checkbox.click();
+              }
+            }, field.selector);
+            break;
+
+          case 'VAS':
+            // Click in the middle of the slider
+            await this.clickVASSlider(page, field.cardBoxSelector);
+            break;
+
+          default:
+            logger.warn(`Unknown field type: ${field.inputType}`);
+        }
+
+        // Small delay between fields
+        await page.waitForFunction(() => new Promise(resolve => setTimeout(resolve, 200)));
+      } catch (error) {
+        logger.error(`Error filling field ${field.questionNumber}:`, error);
+      }
+    }
+  }
+
+  private async selectRadioOption(page: Page, cardBoxSelector: string, position: number): Promise<void> {
+    await page.evaluate((cardSelector, pos) => {
+      const cardBox = document.querySelector(cardSelector);
+      if (cardBox) {
+        const radioInputs = cardBox.querySelectorAll('input[type="radio"]');
+        if (radioInputs[pos]) {
+          (radioInputs[pos] as HTMLInputElement).click();
+        }
+      }
+    }, cardBoxSelector, position);
+  }
+
+  private async selectDropdownOption(page: Page, selector: string, position: number): Promise<void> {
+    const selectElement = await page.$(selector);
+    if (selectElement) {
+      const options = await page.$$eval(selector + ' option', opts => opts.map(opt => (opt as HTMLOptionElement).value));
+      if (options[position + 1]) { // Skip first empty option
+        await page.select(selector, options[position + 1]);
+      }
+    }
+  }
+
+  private async fillTextField(page: Page, selector: string, fieldType: string): Promise<void> {
+    let value = 'Test';
+    switch (fieldType) {
+      case 'email':
+        value = 'test@example.com';
+        break;
+      case 'number':
+        value = '25';
+        break;
+      case 'text':
+      default:
+        value = 'Test Response';
+        break;
+    }
+    
+    await page.click(selector);
+    await page.evaluate(sel => {
+      const input = document.querySelector(sel) as HTMLInputElement;
+      if (input) input.value = '';
+    }, selector);
+    await page.type(selector, value);
+  }
+
+  private async clickVASSlider(page: Page, cardBoxSelector: string): Promise<void> {
+    await page.evaluate((cardSelector) => {
+      const cardBox = document.querySelector(cardSelector);
+      if (cardBox) {
+        const sliderTrack = cardBox.querySelector('[class*="SliderTrack"]');
+        if (sliderTrack) {
+          const rect = sliderTrack.getBoundingClientRect();
+          const clickEvent = new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2
+          });
+          sliderTrack.dispatchEvent(clickEvent);
+        }
+      }
+    }, cardBoxSelector);
+  }
+
+  private async extractCurrentFormTitles(page: Page): Promise<{ longTitle: string; shortName: string }> {
+    return await page.evaluate(() => {
+      const container = document.querySelector('#survey-body-container');
+      if (!container) return { longTitle: '', shortName: '' };
+      
+      // Use same title detection logic as form detector
+      const allPs = container.querySelectorAll('p');
+      let formTitleP = null;
+      
+      for (const p of allPs) {
+        const parent = p.parentElement;
+        if (parent) {
+          const h3InParent = parent.querySelector('h3');
+          if (h3InParent) {
+            formTitleP = p;
+            break;
+          }
+        }
+      }
+      
+      const longTitle = formTitleP?.textContent?.trim() || '';
+      
+      // Get short name (h3)
+      const h3Elements = container.querySelectorAll('h3');
+      const shortName = h3Elements.length > 0 ? h3Elements[0].textContent?.trim() || '' : '';
+      
+      return { longTitle, shortName };
+    });
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from './utils/logger.js';
 export * from './form-analyzer/form-navigator.js';
 export * from './form-analyzer/form-reset-service.js';
 export * from './form-analyzer/survey-detector.js';
+export * from './form-analyzer/baseline-navigator.js';
 
 // Export test generator
 export * from './test-generator/field-type-registry.js';

--- a/packages/shared/src/services/firestore.ts
+++ b/packages/shared/src/services/firestore.ts
@@ -107,6 +107,9 @@ export class FirestoreService {
         viewportHeight: firstForm?.viewportHeight || 0,
         timestamp: firstForm ? admin.firestore.Timestamp.fromDate(new Date(firstForm.timestamp)) : admin.firestore.FieldValue.serverTimestamp(),
         
+        // First form screenshot for preview
+        firstFormOnEntryScreenshotUrl: firstForm?.onEntryScreenshot ? uploadedScreenshots[firstForm.onEntryScreenshot] || '' : '',
+        
         // Summary data from all forms
         fieldsCount: forms.reduce((sum, form) => sum + form.fields.length, 0),
         totalFields: forms.reduce((sum, form) => sum + form.fields.length, 0),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-i18next": "^15.2.0",
+    "react-material-ui-carousel": "^3.4.2",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.1.1",
     "zod": "^3.24.1"

--- a/packages/ui/src/components/analysis/PackageGrid.tsx
+++ b/packages/ui/src/components/analysis/PackageGrid.tsx
@@ -1,13 +1,11 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Grid,
   Card,
   CardContent,
-  CardActions,
   CardMedia,
   Typography,
-  Button,
   Chip,
   Box,
   Skeleton,
@@ -22,6 +20,7 @@ import {
   Schedule as ScheduleIcon,
   Description as DescriptionIcon,
   Preview as PreviewIcon,
+  Check as CheckIcon,
 } from '@mui/icons-material';
 import { useGetAnalysesQuery } from '../../store/services/firestoreApi';
 import { useAppDispatch } from '../../hooks/redux';
@@ -43,6 +42,11 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
     customerId,
     studyId,
   });
+
+  // Update study filter when studyId prop changes
+  useEffect(() => {
+    setStudyFilter(studyId || 'all');
+  }, [studyId]);
 
   // Debug logging
   console.log('PackageGrid debug:', {
@@ -202,6 +206,7 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                 flexDirection: 'column',
                 cursor: 'pointer',
                 transition: 'all 0.3s',
+                overflow: 'hidden',
                 '&:hover': {
                   transform: 'translateY(-4px)',
                   boxShadow: 4,
@@ -209,24 +214,36 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
               }}
               onClick={() => handlePackageClick(analysis)}
             >
-              {/* Screenshot Preview */}
-              <CardMedia
-                component="div"
+              {/* Top bar with chips */}
+              <Box
                 sx={{
-                  height: 140,
-                  bgcolor: 'grey.200',
+                  bgcolor: 'grey.100',
+                  px: 1.5,
+                  py: 0.75,
                   display: 'flex',
+                  justifyContent: 'space-between',
                   alignItems: 'center',
-                  justifyContent: 'center',
-                  position: 'relative',
+                  borderBottom: 1,
+                  borderColor: 'divider',
                 }}
               >
-                <PreviewIcon sx={{ fontSize: 48, color: 'grey.400' }} />
+                {/* Test data chip on the left */}
+                <Box>
+                  {analysis.hasTestData ? (
+                    <Chip
+                      label="Test Data"
+                      size="small"
+                      color="success"
+                      icon={<CheckIcon />}
+                    />
+                  ) : (
+                    <Box /> // Empty box to maintain layout
+                  )}
+                </Box>
+                
+                {/* Language and version chips on the right */}
                 <Box
                   sx={{
-                    position: 'absolute',
-                    top: 8,
-                    right: 8,
                     display: 'flex',
                     gap: 0.5,
                   }}
@@ -243,6 +260,35 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                     variant="outlined"
                   />
                 </Box>
+              </Box>
+
+              {/* Screenshot Preview */}
+              <CardMedia
+                component="div"
+                sx={{
+                  height: 140,
+                  bgcolor: 'grey.200',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  position: 'relative',
+                  overflow: 'hidden',
+                }}
+              >
+                {analysis.firstFormOnEntryScreenshotUrl ? (
+                  <Box
+                    component="img"
+                    src={analysis.firstFormOnEntryScreenshotUrl}
+                    alt={`${analysis.packageName} preview`}
+                    sx={{
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                    }}
+                  />
+                ) : (
+                  <PreviewIcon sx={{ fontSize: 48, color: 'grey.400' }} />
+                )}
               </CardMedia>
 
               <CardContent sx={{ flexGrow: 1 }}>
@@ -271,22 +317,7 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                     </Typography>
                   </Box>
                 </Box>
-
-                {analysis.hasTestData && (
-                  <Chip
-                    label="Test Data Available"
-                    size="small"
-                    color="success"
-                    sx={{ mt: 1 }}
-                  />
-                )}
               </CardContent>
-
-              <CardActions>
-                <Button size="small" fullWidth>
-                  View Details
-                </Button>
-              </CardActions>
             </Card>
           </Grid>
         ))}

--- a/packages/ui/src/components/analysis/PackageGrid.tsx
+++ b/packages/ui/src/components/analysis/PackageGrid.tsx
@@ -20,7 +20,6 @@ import {
   Schedule as ScheduleIcon,
   Description as DescriptionIcon,
   Preview as PreviewIcon,
-  Check as CheckIcon,
 } from '@mui/icons-material';
 import { useGetAnalysesQuery } from '../../store/services/firestoreApi';
 import { useAppDispatch } from '../../hooks/redux';
@@ -207,6 +206,7 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                 cursor: 'pointer',
                 transition: 'all 0.3s',
                 overflow: 'hidden',
+                bgcolor: 'grey.100',
                 '&:hover': {
                   transform: 'translateY(-4px)',
                   boxShadow: 4,
@@ -221,27 +221,13 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                   px: 1.5,
                   py: 0.75,
                   display: 'flex',
-                  justifyContent: 'space-between',
+                  justifyContent: 'flex-end',
                   alignItems: 'center',
                   borderBottom: 1,
                   borderColor: 'divider',
                 }}
               >
-                {/* Test data chip on the left */}
-                <Box>
-                  {analysis.hasTestData ? (
-                    <Chip
-                      label="Test Data"
-                      size="small"
-                      color="success"
-                      icon={<CheckIcon />}
-                    />
-                  ) : (
-                    <Box /> // Empty box to maintain layout
-                  )}
-                </Box>
-                
-                {/* Language and version chips on the right */}
+                {/* Language and version chips */}
                 <Box
                   sx={{
                     display: 'flex',
@@ -284,6 +270,7 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                       width: '100%',
                       height: '100%',
                       objectFit: 'cover',
+                      objectPosition: 'top',
                     }}
                   />
                 ) : (
@@ -291,26 +278,29 @@ const PackageGrid: React.FC<PackageGridProps> = ({ customerId, studyId }) => {
                 )}
               </CardMedia>
 
-              <CardContent sx={{ flexGrow: 1 }}>
-                <Typography gutterBottom variant="h6" component="div">
-                  {analysis.packageName}
-                </Typography>
-                
-                <Typography variant="body2" color="text.secondary">
-                  {analysis.longTitle || analysis.shortName}
-                </Typography>
+              <CardContent sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+                <Box sx={{ flexGrow: 1 }}>
+                  <Typography gutterBottom variant="h6" component="div">
+                    {analysis.packageName}
+                  </Typography>
+                  
+                  <Typography variant="body2" color="text.secondary">
+                    {analysis.longTitle || analysis.shortName}
+                  </Typography>
+                </Box>
 
-                <Box sx={{ mt: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+                {/* Bottom row with field count and date */}
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <DescriptionIcon sx={{ fontSize: 16, mr: 0.5 }} color="action" />
-                    <Typography variant="caption">
+                    <Typography variant="caption" color="text.secondary">
                       {analysis.fieldsCount} fields
                     </Typography>
                   </Box>
                   
                   <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <ScheduleIcon sx={{ fontSize: 16, mr: 0.5 }} color="action" />
-                    <Typography variant="caption">
+                    <Typography variant="caption" color="text.secondary">
                       {analysis.analysisDate?.toDate 
                         ? new Date(analysis.analysisDate.toDate()).toLocaleDateString()
                         : new Date(analysis.analysisDate as any).toLocaleDateString()}

--- a/packages/ui/src/components/screenshots/ScreenshotViewer.tsx
+++ b/packages/ui/src/components/screenshots/ScreenshotViewer.tsx
@@ -10,14 +10,12 @@ import {
   DialogTitle,
   Typography,
   CircularProgress,
-  ImageList,
-  ImageListItem,
-  ImageListItemBar,
   useTheme,
   useMediaQuery,
   Tooltip,
   Stack,
 } from '@mui/material';
+import Carousel from 'react-material-ui-carousel';
 import {
   ZoomIn as ZoomInIcon,
   ZoomOut as ZoomOutIcon,
@@ -97,7 +95,7 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({ analysisId }) => {
   }
 
   return (
-    <Box>
+    <Box sx={{ width: '100%', maxWidth: '100%', overflow: 'hidden' }}>
       {/* Form Tabs */}
       <Paper sx={{ mb: 2 }}>
         <Tabs
@@ -118,63 +116,75 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({ analysisId }) => {
 
       {/* Form Screenshots */}
       {selectedForm && (
-        <Box>
+        <Box sx={{ width: '100%', overflow: 'hidden' }}>
           {/* On-Entry/On-Exit Screenshots */}
-          <Stack direction={isMobile ? 'column' : 'row'} spacing={2} sx={{ mb: 3 }}>
-            {selectedForm.onEntryScreenshotUrl && (
-              <Paper
+          {(selectedForm.onEntryScreenshotUrl || selectedForm.onExitScreenshotUrl) && (
+            <Box sx={{ mb: 3 }}>
+              <Carousel
+                autoPlay={false}
+                cycleNavigation={false}
+                navButtonsAlwaysInvisible
+                indicators={true}
+                animation="slide"
+                swipe={true}
                 sx={{
-                  p: 1,
-                  flex: 1,
-                  cursor: 'pointer',
-                  '&:hover': { boxShadow: 3 },
+                  width: '100%',
+                  maxWidth: isMobile ? '100%' : '600px',
+                  mx: 'auto',
                 }}
-                onClick={() => handleImageClick(selectedForm.onEntryScreenshotUrl)}
               >
-                <Typography variant="subtitle2" gutterBottom>
-                  On-Entry Screenshot
-                </Typography>
-                <Box
-                  component="img"
-                  src={selectedForm.onEntryScreenshotUrl}
-                  alt="On-Entry"
-                  sx={{
-                    width: '100%',
-                    height: 200,
-                    objectFit: 'contain',
-                    bgcolor: 'grey.100',
-                  }}
-                />
-              </Paper>
-            )}
-            
-            {selectedForm.onExitScreenshotUrl && (
-              <Paper
-                sx={{
-                  p: 1,
-                  flex: 1,
-                  cursor: 'pointer',
-                  '&:hover': { boxShadow: 3 },
-                }}
-                onClick={() => handleImageClick(selectedForm.onExitScreenshotUrl)}
-              >
-                <Typography variant="subtitle2" gutterBottom>
-                  On-Exit Screenshot
-                </Typography>
-                <Box
-                  component="img"
-                  src={selectedForm.onExitScreenshotUrl}
-                  alt="On-Exit"
-                  sx={{
-                    width: '100%',
-                    height: 200,
-                    objectFit: 'contain',
-                    bgcolor: 'grey.100',
-                  }}
-                />
-              </Paper>
-            )}
-          </Stack>
+                {selectedForm.onEntryScreenshotUrl && (
+                  <Paper
+                    sx={{
+                      p: 2,
+                      cursor: 'pointer',
+                    }}
+                    onClick={() => handleImageClick(selectedForm.onEntryScreenshotUrl)}
+                  >
+                    <Typography variant="subtitle2" gutterBottom align="center">
+                      On-Entry Screenshot
+                    </Typography>
+                    <Box
+                      component="img"
+                      src={selectedForm.onEntryScreenshotUrl}
+                      alt="On-Entry"
+                      sx={{
+                        width: '100%',
+                        height: 400,
+                        objectFit: 'contain',
+                        bgcolor: 'grey.100',
+                      }}
+                    />
+                  </Paper>
+                )}
+                
+                {selectedForm.onExitScreenshotUrl && (
+                  <Paper
+                    sx={{
+                      p: 2,
+                      cursor: 'pointer',
+                    }}
+                    onClick={() => handleImageClick(selectedForm.onExitScreenshotUrl)}
+                  >
+                    <Typography variant="subtitle2" gutterBottom align="center">
+                      On-Exit Screenshot
+                    </Typography>
+                    <Box
+                      component="img"
+                      src={selectedForm.onExitScreenshotUrl}
+                      alt="On-Exit"
+                      sx={{
+                        width: '100%',
+                        height: 400,
+                        objectFit: 'contain',
+                        bgcolor: 'grey.100',
+                      }}
+                    />
+                  </Paper>
+                )}
+              </Carousel>
+            </Box>
+          )}
 
           {/* Field Screenshots */}
           <Typography variant="h6" gutterBottom>
@@ -186,48 +196,82 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({ analysisId }) => {
               <CircularProgress />
             </Box>
           ) : fields && fields.length > 0 ? (
-            <ImageList cols={isMobile ? 1 : 3} gap={16}>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(2, minmax(0, 1fr))',
+                },
+                gap: 2,
+                width: '100%',
+                maxWidth: '100%',
+                overflow: 'hidden',
+              }}
+            >
               {fields.map((field) => (
-                <ImageListItem
+                <Paper
                   key={field.id}
                   sx={{
+                    p: 1,
                     cursor: 'pointer',
-                    '& .MuiImageListItemBar-root': {
-                      background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 70%, rgba(0,0,0,0) 100%)',
+                    transition: 'all 0.2s',
+                    width: '100%',
+                    overflow: 'hidden',
+                    '&:hover': { 
+                      boxShadow: 3,
+                      transform: 'translateY(-2px)',
                     },
                   }}
                   onClick={() => handleImageClick(field.screenshotUrl)}
                 >
-                  <Box
-                    component="img"
-                    src={field.screenshotUrl}
-                    alt={field.questionText}
-                    loading="lazy"
-                    sx={{
-                      height: 250,
-                      objectFit: 'cover',
-                      bgcolor: 'grey.100',
-                    }}
-                  />
-                  <ImageListItemBar
-                    title={`${field.questionNumber} ${field.questionText}`}
-                    subtitle={field.inputType}
-                    actionIcon={
-                      <IconButton
-                        sx={{ color: 'rgba(255, 255, 255, 0.54)' }}
-                        aria-label={`download ${field.questionNumber}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDownload(field.screenshotUrl, field.screenshotFilename);
-                        }}
-                      >
-                        <DownloadIcon />
-                      </IconButton>
-                    }
-                  />
-                </ImageListItem>
+                  <Stack spacing={1}>
+                    <Box sx={{ p: 1 }}>
+                      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start' }}>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography variant="subtitle2" noWrap>
+                            {field.questionNumber} {field.questionText}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {field.inputType} {field.isRequired && '• Required'}
+                          </Typography>
+                        </Box>
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDownload(field.screenshotUrl, field.screenshotFilename);
+                          }}
+                          sx={{ ml: 1 }}
+                        >
+                          <DownloadIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    </Box>
+                    <Box
+                      component="img"
+                      src={field.screenshotUrl}
+                      alt={field.questionText}
+                      loading="lazy"
+                      sx={{
+                        width: '100%',
+                        height: 300,
+                        objectFit: 'contain',
+                        bgcolor: 'grey.100',
+                        borderRadius: 1,
+                      }}
+                    />
+                    {field.choices && field.choices.length > 0 && (
+                      <Box sx={{ px: 1, pb: 1 }}>
+                        <Typography variant="caption" color="text.secondary">
+                          {field.choices.length} choices
+                        </Typography>
+                      </Box>
+                    )}
+                  </Stack>
+                </Paper>
               ))}
-            </ImageList>
+            </Box>
           ) : (
             <Box sx={{ textAlign: 'center', p: 4 }}>
               <Typography variant="body2" color="text.secondary">

--- a/packages/ui/src/store/services/firestoreApi.ts
+++ b/packages/ui/src/store/services/firestoreApi.ts
@@ -69,6 +69,7 @@ export interface SurveyAnalysis {
   hasTestData: boolean;
   testDataSummary?: any;
   screenshotsPath: string;
+  firstFormOnEntryScreenshotUrl?: string;
   status: string;
   processingDuration: number;
   createdAt: Timestamp;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       react-i18next:
         specifier: ^15.2.0
         version: 15.5.3(i18next@23.16.8)(react-dom@18.3.1)(react@18.3.1)(typescript@5.8.3)
+      react-material-ui-carousel:
+        specifier: ^3.4.2
+        version: 3.4.2(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/icons-material@6.4.12)(@mui/material@7.1.2)(@types/react@18.3.23)(react-dom@18.3.1)(react@18.3.1)
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@18.3.23)(react@18.3.1)
@@ -333,11 +336,25 @@ packages:
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
     dev: false
 
+  /@emotion/is-prop-valid@0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: false
+    optional: true
+
   /@emotion/is-prop-valid@1.3.1:
     resolution: {integrity: sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==}
     dependencies:
       '@emotion/memoize': 0.9.0
     dev: false
+
+  /@emotion/memoize@0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@emotion/memoize@0.9.0:
     resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
@@ -1321,6 +1338,23 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
     dev: false
 
+  /@mui/private-theming@5.17.1(@types/react@18.3.23)(react@18.3.1):
+    resolution: {integrity: sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
+      '@types/react': 18.3.23
+      prop-types: 15.8.1
+      react: 18.3.1
+    dev: false
+
   /@mui/private-theming@7.1.1(@types/react@18.3.23)(react@18.3.1):
     resolution: {integrity: sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==}
     engines: {node: '>=14.0.0'}
@@ -1334,6 +1368,28 @@ packages:
       '@babel/runtime': 7.27.6
       '@mui/utils': 7.1.1(@types/react@18.3.23)(react@18.3.1)
       '@types/react': 18.3.23
+      prop-types: 15.8.1
+      react: 18.3.1
+    dev: false
+
+  /@mui/styled-engine@5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@18.3.1):
+    resolution: {integrity: sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@18.3.23)(react@18.3.1)
+      csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
     dev: false
@@ -1357,6 +1413,36 @@ packages:
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@18.3.23)(react@18.3.1)
+      csstype: 3.1.3
+      prop-types: 15.8.1
+      react: 18.3.1
+    dev: false
+
+  /@mui/system@5.17.1(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@18.3.23)(react@18.3.1):
+    resolution: {integrity: sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@18.3.23)(react@18.3.1)
+      '@mui/private-theming': 5.17.1(@types/react@18.3.23)(react@18.3.1)
+      '@mui/styled-engine': 5.16.14(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(react@18.3.1)
+      '@mui/types': 7.2.24(@types/react@18.3.23)
+      '@mui/utils': 5.17.1(@types/react@18.3.23)(react@18.3.1)
+      '@types/react': 18.3.23
+      clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.3.1
@@ -1392,6 +1478,17 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@mui/types@7.2.24(@types/react@18.3.23):
+    resolution: {integrity: sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.23
+    dev: false
+
   /@mui/types@7.4.3(@types/react@18.3.23):
     resolution: {integrity: sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==}
     peerDependencies:
@@ -1402,6 +1499,26 @@ packages:
     dependencies:
       '@babel/runtime': 7.27.6
       '@types/react': 18.3.23
+    dev: false
+
+  /@mui/utils@5.17.1(@types/react@18.3.23)(react@18.3.1):
+    resolution: {integrity: sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.27.6
+      '@mui/types': 7.2.24(@types/react@18.3.23)
+      '@types/prop-types': 15.7.15
+      '@types/react': 18.3.23
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 19.1.0
     dev: false
 
   /@mui/utils@7.1.1(@types/react@18.3.23)(react@18.3.1):
@@ -2577,6 +2694,29 @@ packages:
     dev: false
     optional: true
 
+  /framer-motion@4.1.17(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==}
+    peerDependencies:
+      react: '>=16.8 || ^17.0.0'
+      react-dom: '>=16.8 || ^17.0.0'
+    dependencies:
+      framesync: 5.3.0
+      hey-listen: 1.0.8
+      popmotion: 9.3.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      style-value-types: 4.1.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
+  /framesync@5.3.0:
+    resolution: {integrity: sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2770,6 +2910,10 @@ packages:
     requiresBuild: true
     dependencies:
       function-bind: 1.1.2
+    dev: false
+
+  /hey-listen@1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
     dev: false
 
   /hoist-non-react-statics@3.3.2:
@@ -3240,6 +3384,15 @@ packages:
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  /popmotion@9.3.6:
+    resolution: {integrity: sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==}
+    dependencies:
+      framesync: 5.3.0
+      hey-listen: 1.0.8
+      style-value-types: 4.1.4
+      tslib: 2.8.1
+    dev: false
+
   /postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3403,6 +3556,28 @@ packages:
 
   /react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
+    dev: false
+
+  /react-material-ui-carousel@3.4.2(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@mui/icons-material@6.4.12)(@mui/material@7.1.2)(@types/react@18.3.23)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-jUbC5aBWqbbbUOOdUe3zTVf4kMiZFwKJqwhxzHgBfklaXQbSopis4iWAHvEOLcZtSIJk4JAGxKE0CmxDoxvUuw==}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      '@mui/icons-material': ^5.0.0
+      '@mui/material': ^5.0.0
+      react: ^17.0.1 || ^18.0.0
+      react-dom: ^17.0.2 || ^18.0.0
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0)(@types/react@18.3.23)(react@18.3.1)
+      '@mui/icons-material': 6.4.12(@mui/material@7.1.2)(@types/react@18.3.23)(react@18.3.1)
+      '@mui/material': 7.1.2(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@18.3.23)(react-dom@18.3.1)(react@18.3.1)
+      '@mui/system': 5.17.1(@emotion/react@11.14.0)(@emotion/styled@11.14.0)(@types/react@18.3.23)(react@18.3.1)
+      framer-motion: 4.1.17(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /react-redux@9.2.0(@types/react@18.3.23)(react@18.3.1):
@@ -3703,6 +3878,13 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /style-value-types@4.1.4:
+    resolution: {integrity: sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==}
+    dependencies:
+      hey-listen: 1.0.8
+      tslib: 2.8.1
+    dev: false
 
   /stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}


### PR DESCRIPTION
## Summary
This PR implements multi-language support for Form-Shot using an EN baseline approach as described in issue #12.

- Non-EN analyses now require an existing EN analysis as a baseline
- EN baseline can be provided via Firestore (automatic lookup) or local file (--en-baseline option)
- Baseline navigation ensures consistent form traversal across languages

## Changes

### New Features
- Added `--en-baseline` option to analyze command for manual baseline file input
- Implemented automatic EN baseline lookup from Firestore for non-EN analyses
- Created `BaselineNavigator` service that uses EN form structure to navigate non-EN versions
- Added `getENBaselineAnalysis` method to FirestoreService for querying EN baselines

### Documentation
- Updated README with comprehensive multi-language workflow examples
- Added multi-language support to features list

### Implementation Details
- Language validation happens early in the analyze command
- EN baseline is loaded before browser launch for efficiency
- Form navigation uses baseline field selectors and types
- Screenshots capture language-specific content while following EN structure

## Test Plan
1. Analyze an EN version of a survey
2. Upload to Firestore (for automatic lookup) or keep local (for manual baseline)
3. Analyze a non-EN version:
   - With Firestore: should automatically find EN baseline
   - Without Firestore: use --en-baseline option with path to EN analysis.json
4. Verify non-EN analysis captures correct screenshots with localized text
5. Verify form navigation follows EN structure

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)